### PR TITLE
Xcode 26 + Redesign with meter grid

### DIFF
--- a/TunApp.xcodeproj/project.pbxproj
+++ b/TunApp.xcodeproj/project.pbxproj
@@ -265,7 +265,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TunApp/Preview Content\"";
-				DEVELOPMENT_TEAM = XJL68ZTB2X;
+				DEVELOPMENT_TEAM = FHXSPA8M8R;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app uses the microphone to capture audio.";
@@ -295,7 +295,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TunApp/Preview Content\"";
-				DEVELOPMENT_TEAM = XJL68ZTB2X;
+				DEVELOPMENT_TEAM = FHXSPA8M8R;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app uses the microphone to capture audio.";

--- a/TunApp.xcodeproj/project.pbxproj
+++ b/TunApp.xcodeproj/project.pbxproj
@@ -274,6 +274,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -304,6 +305,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 18.6;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/TunApp.xcodeproj/xcuserdata/ymziya.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/TunApp.xcodeproj/xcuserdata/ymziya.xcuserdatad/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -20,5 +20,85 @@
             landmarkType = "0">
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "8AEC1CFC-D671-4E86-B84F-CBFDAF20AB1C"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TunApp/TuningManager/TuningManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "51"
+            endingLineNumber = "51"
+            landmarkName = "update(_:_:)"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "DF0E5783-1565-470B-957A-F5DA0AC50D86"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TunApp/TuningManager/TuningManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "45"
+            endingLineNumber = "45"
+            landmarkName = "init()"
+            landmarkType = "7">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "678A82E4-188F-4BF8-9093-C8214AEAE460"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TunApp/TuningManager/TuningManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "39"
+            endingLineNumber = "39"
+            landmarkName = "tracker"
+            landmarkType = "24">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "E911694A-936B-4328-B083-D2427DBE5DDB"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TunApp/TuningManager/TuningManager.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "40"
+            endingLineNumber = "40"
+            landmarkName = "tracker"
+            landmarkType = "24">
+         </BreakpointContent>
+      </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.FileBreakpoint">
+         <BreakpointContent
+            uuid = "39E6913C-674D-4DCF-BF62-8C093DBCBC55"
+            shouldBeEnabled = "No"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            filePath = "TunApp/Grid.swift"
+            startingColumnNumber = "9223372036854775807"
+            endingColumnNumber = "9223372036854775807"
+            startingLineNumber = "99"
+            endingLineNumber = "99"
+            landmarkName = "body"
+            landmarkType = "24">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>

--- a/TunApp.xcodeproj/xcuserdata/ymziya.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/TunApp.xcodeproj/xcuserdata/ymziya.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,26 +7,20 @@
 		<key>AudioKit (Playground).xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>3</integer>
+			<integer>2</integer>
 		</dict>
 		<key>SoundpipeAudioKit (Playground).xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>2</integer>
+			<integer>1</integer>
 		</dict>
 		<key>TunApp.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>1</integer>
+			<integer>0</integer>
 		</dict>
 	</dict>
 	<key>SuppressBuildableAutocreation</key>
-	<dict>
-		<key>780C90222D3CB279006E24D4</key>
-		<dict>
-			<key>primary</key>
-			<true/>
-		</dict>
-	</dict>
+	<dict/>
 </dict>
 </plist>

--- a/TunApp/ChromaticTuner/ChromaticTunerView.swift
+++ b/TunApp/ChromaticTuner/ChromaticTunerView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct ChromaticTunerView: View {
     
     @StateObject var viewModel: ChromaticTunerViewModel
-    @State private var meterAngle: Double = 0
+    @State private var gaugeAngle: Double = 0
     
     init(tuningManager: TuningManager) {
         _viewModel = StateObject(
@@ -20,7 +20,7 @@ struct ChromaticTunerView: View {
     
     var body: some View {
         VStack {
-            Meter(angle: meterAngle)
+            Gauge(angle: gaugeAngle)
             HStack {
                 Text(viewModel.viewData.prevNoteName)
                 Text(viewModel.viewData.noteName)
@@ -32,7 +32,7 @@ struct ChromaticTunerView: View {
         }
         .onChange(of: viewModel.viewData.distance) { _, newValue in
             withAnimation {
-                meterAngle = Double(viewModel.viewData.distance * 72.0)
+                gaugeAngle = Double(viewModel.viewData.distance * 72.0)
             }
         }
     }

--- a/TunApp/ChromaticTuner/Meter.swift
+++ b/TunApp/ChromaticTuner/Meter.swift
@@ -1,5 +1,5 @@
 //
-//  Meter.swift
+//  Gauge.swift
 //  TunApp
 //
 //  Created by Yassin Mziya on 1/25/25.
@@ -7,7 +7,7 @@
 
 import SwiftUI
 
-struct Meter: View {
+struct Gauge: View {
     
     private let MAX_ANGLE = 72.0
     let angle: Double
@@ -15,7 +15,7 @@ struct Meter: View {
     var body: some View {
         VStack {
             ZStack() {
-                MeterDial()
+                GaugeDial()
                     .stroke(.cyan, style: StrokeStyle(lineWidth: 2.0, lineCap: .round))
                     .frame(height: 200)
                 Color(.systemCyan)
@@ -30,5 +30,5 @@ struct Meter: View {
 }
 
 #Preview {
-    Meter(angle: -90)
+    Gauge(angle: -90)
 }

--- a/TunApp/ChromaticTuner/MeterDial.swift
+++ b/TunApp/ChromaticTuner/MeterDial.swift
@@ -1,5 +1,5 @@
 //
-//  MeterDial.swift
+//  GaugeDial.swift
 //  TunApp
 //
 //  Created by Yassin Mziya on 1/26/25.
@@ -8,7 +8,7 @@
 import Foundation
 import SwiftUI
 
-struct MeterDial: Shape {
+struct GaugeDial: Shape {
     
     private(set) var numOfTicks = 9
     private(set) var sweepAngle =  Angle(degrees: 135)
@@ -57,7 +57,7 @@ struct MeterDial: Shape {
 }
 
 #Preview {
-    MeterDial(numOfTicks: 6)
+    GaugeDial(numOfTicks: 6)
         .stroke(.cyan, style: StrokeStyle(lineWidth: 2.0, lineCap: .round))
         .frame(width: 300, height: 200)
 }

--- a/TunApp/ChromaticTuner/MeterDial.swift
+++ b/TunApp/ChromaticTuner/MeterDial.swift
@@ -31,8 +31,8 @@ struct MeterDial: Shape {
             
             // Calculate start piont on circumfrence
             let startPoint = CGPoint(
-                x: radius * cos(angle.radians) + center.x,
-                y: radius * sin(angle.radians) + center.y
+                x: radius, // * cos(angle.radians) + center.x,
+                y: radius // * sin(angle.radians) + center.y
             )
             
             // Calculate direction vector

--- a/TunApp/Grid.swift
+++ b/TunApp/Grid.swift
@@ -9,6 +9,20 @@ import SwiftUI
 
 struct Grid: View {
     
+    var body: some View {
+        ZStack {
+            GridLinesLayer()
+            TicksLayer()
+        }
+        .gradientMask()
+    }
+}
+
+struct GridLinesLayer: View {
+    
+    private let strokeWidth: CGFloat = 1.0
+    private let strokeColor = Color.gray.opacity(0.1)
+    private let numberOfSquaresAccrossWidth = 18.0
     private let speed: CGFloat = 32
     
     @State private var startDate = Date()
@@ -17,7 +31,7 @@ struct Grid: View {
         TimelineView(.animation) { timeline in
             ZStack {
                 Canvas { context, size in
-                    let spacing: CGFloat = size.width/18.0
+                    let spacing: CGFloat = size.width/numberOfSquaresAccrossWidth
                     let elapsed = timeline.date.timeIntervalSince(startDate)
                     let rawOffset = elapsed * speed
                     let offset = rawOffset.truncatingRemainder(dividingBy: spacing)
@@ -28,7 +42,7 @@ struct Grid: View {
                         let y = (CGFloat(i) * spacing) - offset
                         path.move(to: .init(x: .zero, y: y))
                         path.addLine(to: .init(x: size.width, y: y))
-                        context.stroke(path, with: .color(.gray.opacity(0.2)), lineWidth: 1)
+                        context.stroke(path, with: .color(strokeColor), lineWidth: strokeWidth)
                     }
                     let numberOfVerticalLines = size.width / spacing
                     for i in 0...Int(numberOfVerticalLines) {
@@ -36,23 +50,81 @@ struct Grid: View {
                         let x = (CGFloat(i) * spacing)
                         path.move(to: .init(x: x, y: .zero))
                         path.addLine(to: .init(x: x, y: size.height))
-                        context.stroke(path, with: .color(.gray.opacity(0.2)), lineWidth: 1)
+                        context.stroke(path, with: .color(strokeColor), lineWidth: strokeWidth)
                     }
                 }
-                .mask(
-                    LinearGradient(
-                        gradient: Gradient(stops: [
-                            .init(color: .clear, location: 0.0),
-                            .init(color: .black, location: 0.2),
-                            .init(color: .black, location: 0.6),
-                            .init(color: .clear, location: 1.0),
-                        ]),
-                        startPoint: .top,
-                        endPoint: .bottom
-                    )
-                )
+                .gradientMask()
             }
         }
+    }
+}
+
+private struct TicksLayer: View {
+    
+    private let speed: CGFloat = 0.5
+    @State private var startDate = Date()
+    @StateObject var valueBuffer = ValueBuffer()
+    
+    @State var timer = Timer.publish(every: 0.01, on: .main, in: .common).autoconnect()
+    
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            Canvas { context, size in
+                var path = Path()
+                let x = size.width / 2.0
+                path.move(to: .init(x: x, y: 0))
+                path.addLine(to: .init(x: x, y: size.height))
+                context.stroke(path, with: .color(.red), lineWidth: 1.2)
+                
+                for (index, value) in valueBuffer.values.enumerated() {
+                    var path = Path()
+                    let x = size.width / 2.0 + value
+                    let y =  size.height / 2.0  - CGFloat(index) * speed
+                    path.addEllipse(
+                        in: CGRect(
+                            origin: CGPoint(x: x, y: y),
+                            size: CGSize(width: 4, height: 4)
+                        )
+                    )
+                    context.fill(path, with: .color(.red))
+                }
+            }
+        }
+        .onReceive(timer) { _ in
+            valueBuffer.add(.random(in: -1000...1000))
+//            valueBuffer.add(167)
+        }
+    }
+}
+
+fileprivate class ValueBuffer: ObservableObject {
+    
+    private let limit = 1000
+    @Published private(set)var values = [CGFloat]()
+    
+    func add(_ value: CGFloat) {
+        if (values.count == limit) {
+            _ = values.removeLast()
+        }
+        values.insert(value, at: 0)
+    }
+}
+
+fileprivate extension View {
+    
+    func gradientMask() -> some View {
+        self.mask(
+            LinearGradient(
+                gradient: Gradient(stops: [
+                    .init(color: .clear, location: 0.0),
+                    .init(color: .black, location: 0.05),
+                    .init(color: .black, location: 0.95),
+                    .init(color: .clear, location: 1.0),
+                ]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
     }
 }
 

--- a/TunApp/Grid.swift
+++ b/TunApp/Grid.swift
@@ -7,16 +7,41 @@
 
 import SwiftUI
 
+// MARK: - Grid
+
 struct Grid: View {
+    
+    @EnvironmentObject var tuningManager: TuningManager
     
     var body: some View {
         ZStack {
             GridLinesLayer()
-            TicksLayer()
+                .gradientMask()
+            TickerLayer()
+            NeedleLayer()
         }
-        .gradientMask()
     }
 }
+
+fileprivate extension View {
+    
+    func gradientMask() -> some View {
+        self.mask(
+            LinearGradient(
+                gradient: Gradient(stops: [
+                    .init(color: .clear, location: 0.0),
+                    .init(color: .black, location: 0.1),
+                    .init(color: .black, location: 0.9),
+                    .init(color: .clear, location: 1.0),
+                ]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
+    }
+}
+
+// MARK: - GridLinesLayer
 
 struct GridLinesLayer: View {
     
@@ -39,7 +64,7 @@ struct GridLinesLayer: View {
                     let numberOfHorizontalLines = size.height / spacing
                     for i in 0...Int(numberOfHorizontalLines) {
                         var path = Path()
-                        let y = (CGFloat(i) * spacing) - offset
+                        let y = (CGFloat(i) * spacing) + offset
                         path.move(to: .init(x: .zero, y: y))
                         path.addLine(to: .init(x: size.width, y: y))
                         context.stroke(path, with: .color(strokeColor), lineWidth: strokeWidth)
@@ -59,27 +84,23 @@ struct GridLinesLayer: View {
     }
 }
 
-private struct TicksLayer: View {
+// MARK: - TickerLayer
+
+private struct TickerLayer: View {
     
-    private let speed: CGFloat = 0.5
-    @State private var startDate = Date()
+    private let speed: CGFloat = 32
+    
     @StateObject var valueBuffer = ValueBuffer()
-    
-    @State var timer = Timer.publish(every: 0.01, on: .main, in: .common).autoconnect()
+    @EnvironmentObject var tuningManager: TuningManager
     
     var body: some View {
         TimelineView(.animation) { timeline in
             Canvas { context, size in
-                var path = Path()
-                let x = size.width / 2.0
-                path.move(to: .init(x: x, y: 0))
-                path.addLine(to: .init(x: x, y: size.height))
-                context.stroke(path, with: .color(.red), lineWidth: 1.2)
-                
-                for (index, value) in valueBuffer.values.enumerated() {
+                for value in valueBuffer.values {
                     var path = Path()
-                    let x = size.width / 2.0 + value
-                    let y =  size.height / 2.0  - CGFloat(index) * speed
+                    let x = size.width / 2.0 + value.1
+                    let elapsed = timeline.date.timeIntervalSince(value.0)
+                    let y = 64 + speed * elapsed
                     path.addEllipse(
                         in: CGRect(
                             origin: CGPoint(x: x, y: y),
@@ -90,44 +111,69 @@ private struct TicksLayer: View {
                 }
             }
         }
-        .onReceive(timer) { _ in
-            valueBuffer.add(.random(in: -1000...1000))
-//            valueBuffer.add(167)
+        .onReceive(tuningManager.$data) { tuningData in
+
+            valueBuffer.add(tuningData.boundedValue)
+        }
+    }
+}
+
+
+// MARK: - CenterRulingLayer
+
+private struct NeedleLayer: View {
+    
+    @EnvironmentObject var tuningManager: TuningManager
+    
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack {
+                Path { path in
+                    let x = geometry.size.width / 2.0
+                    path.move(to: .init(x: x, y: 0))
+                    path.addLine(to: .init(x: x, y: geometry.size.height))
+                }
+                .stroke(Color.gray, lineWidth: 1.2)
+                Canvas { context, size in
+                    var path = Path()
+                    let height: CGFloat = 32.0
+                    let x = size.width / 2.0 + tuningManager.data.boundedValue - height/2.0
+                    path.addEllipse(
+                        in: CGRect(
+                            origin: CGPoint(x: x, y: height),
+                            size: CGSize(width: height, height: height)
+                        )
+                    )
+                    context.fill(path, with: .color(.black))
+                    context.stroke(path, with: .color(.green), lineWidth: 2)
+                }
+            }
         }
     }
 }
 
 fileprivate class ValueBuffer: ObservableObject {
     
-    private let limit = 1000
-    @Published private(set)var values = [CGFloat]()
+    private let limit = 3000
+    @Published private(set)var values = [(Date, CGFloat)]()
     
     func add(_ value: CGFloat) {
         if (values.count == limit) {
             _ = values.removeLast()
         }
-        values.insert(value, at: 0)
+        values.insert((Date.now, value), at: 0)
     }
 }
 
-fileprivate extension View {
+fileprivate extension TuningData {
     
-    func gradientMask() -> some View {
-        self.mask(
-            LinearGradient(
-                gradient: Gradient(stops: [
-                    .init(color: .clear, location: 0.0),
-                    .init(color: .black, location: 0.05),
-                    .init(color: .black, location: 0.95),
-                    .init(color: .clear, location: 1.0),
-                ]),
-                startPoint: .top,
-                endPoint: .bottom
-            )
-        )
+    var boundedValue: CGFloat {
+        let scaledValue = CGFloat(distance) * 250
+        return min(max(scaledValue, -150), 150)
     }
 }
 
 #Preview {
     Grid()
+        .environmentObject(TuningManager())
 }

--- a/TunApp/Grid.swift
+++ b/TunApp/Grid.swift
@@ -1,0 +1,61 @@
+//
+//  Grid.swift
+//  TunApp
+//
+//  Created by Yassin Mziya on 10/13/25.
+//
+
+import SwiftUI
+
+struct Grid: View {
+    
+    private let speed: CGFloat = 32
+    
+    @State private var startDate = Date()
+
+    var body: some View {
+        TimelineView(.animation) { timeline in
+            ZStack {
+                Canvas { context, size in
+                    let spacing: CGFloat = size.width/18.0
+                    let elapsed = timeline.date.timeIntervalSince(startDate)
+                    let rawOffset = elapsed * speed
+                    let offset = rawOffset.truncatingRemainder(dividingBy: spacing)
+                    
+                    let numberOfHorizontalLines = size.height / spacing
+                    for i in 0...Int(numberOfHorizontalLines) {
+                        var path = Path()
+                        let y = (CGFloat(i) * spacing) - offset
+                        path.move(to: .init(x: .zero, y: y))
+                        path.addLine(to: .init(x: size.width, y: y))
+                        context.stroke(path, with: .color(.gray.opacity(0.2)), lineWidth: 1)
+                    }
+                    let numberOfVerticalLines = size.width / spacing
+                    for i in 0...Int(numberOfVerticalLines) {
+                        var path = Path()
+                        let x = (CGFloat(i) * spacing)
+                        path.move(to: .init(x: x, y: .zero))
+                        path.addLine(to: .init(x: x, y: size.height))
+                        context.stroke(path, with: .color(.gray.opacity(0.2)), lineWidth: 1)
+                    }
+                }
+                .mask(
+                    LinearGradient(
+                        gradient: Gradient(stops: [
+                            .init(color: .clear, location: 0.0),
+                            .init(color: .black, location: 0.2),
+                            .init(color: .black, location: 0.6),
+                            .init(color: .clear, location: 1.0),
+                        ]),
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
+                )
+            }
+        }
+    }
+}
+
+#Preview {
+    Grid()
+}

--- a/TunApp/TunAppApp.swift
+++ b/TunApp/TunAppApp.swift
@@ -11,11 +11,12 @@ import SwiftUI
 struct TunAppApp: App {
     
     @Environment(\.scenePhase) private var scenePhase
-    private let tuniningManager = TuningManager()
+    @StateObject var tuniningManager = TuningManager()
     
     var body: some Scene {
         WindowGroup {
             Tuner()
+                .environmentObject(tuniningManager)
         }
     }
     

--- a/TunApp/TunAppApp.swift
+++ b/TunApp/TunAppApp.swift
@@ -17,6 +17,16 @@ struct TunAppApp: App {
         WindowGroup {
             Tuner()
                 .environmentObject(tuniningManager)
+                .onChange(of: scenePhase) { phase in
+                    switch phase {
+                    case .active:
+                        tuniningManager.start()
+                    case .background, .inactive:
+                        tuniningManager.stop()
+                    default:
+                        tuniningManager.stop()
+                    }
+                }
         }
     }
     

--- a/TunApp/TunAppApp.swift
+++ b/TunApp/TunAppApp.swift
@@ -15,17 +15,7 @@ struct TunAppApp: App {
     
     var body: some Scene {
         WindowGroup {
-            ChromaticTunerView(tuningManager: tuniningManager)
-                .onChange(of: scenePhase) { phase in
-                    switch phase {
-                    case .active:
-                        tuniningManager.start()
-                    case .background, .inactive:
-                        tuniningManager.stop()
-                    default:
-                        tuniningManager.stop()
-                    }
-                }
+            Tuner()
         }
     }
     

--- a/TunApp/Tuner.swift
+++ b/TunApp/Tuner.swift
@@ -8,23 +8,48 @@
 import SwiftUI
 
 struct Tuner: View {
+    
+    @State var showSheet = true
+    @EnvironmentObject var tuningManager: TuningManager
+    
     var body: some View {
-        ZStack {
+        VStack {
+            HStack {
+                Text(TuningUtils.flatSymbol)
+                    .font(.system(size: 36))
+                Spacer()
+                Text(TuningUtils.sharpSymbol)
+                    .font(.system(size: 36))
+            }
+            .padding()
             Grid()
+        }
+        .sheet(isPresented: $showSheet) {
+            MainContent()
         }
     }
 }
 
 private struct MainContent: View {
+    
+    @EnvironmentObject var tuningManager: TuningManager
+    
     var body: some View {
         VStack {
             Spacer()
-            
+            Text(tuningManager.data.noteName())
+                .font(.system(size: 96))
+            + Text("\(tuningManager.data.ocatave)")
+                .font(.system(size: 48))
+                .baselineOffset(36)
+            Spacer()
         }
+        .presentationDetents([.medium])
+        .presentationBackgroundInteraction(.enabled)
     }
-    
 }
 
 #Preview {
     Tuner()
+        .environmentObject(TuningManager())
 }

--- a/TunApp/Tuner.swift
+++ b/TunApp/Tuner.swift
@@ -1,0 +1,30 @@
+//
+//  Tuner.swift
+//  TunApp
+//
+//  Created by Yassin Mziya on 10/13/25.
+//
+
+import SwiftUI
+
+struct Tuner: View {
+    var body: some View {
+        ZStack {
+            Grid()
+        }
+    }
+}
+
+private struct MainContent: View {
+    var body: some View {
+        VStack {
+            Spacer()
+            
+        }
+    }
+    
+}
+
+#Preview {
+    Tuner()
+}

--- a/TunApp/Tuner.swift
+++ b/TunApp/Tuner.swift
@@ -13,16 +13,19 @@ struct Tuner: View {
     @EnvironmentObject var tuningManager: TuningManager
     
     var body: some View {
-        VStack {
-            HStack {
-                Text(TuningUtils.flatSymbol)
-                    .font(.system(size: 36))
-                Spacer()
-                Text(TuningUtils.sharpSymbol)
-                    .font(.system(size: 36))
-            }
-            .padding()
+        ZStack {
             Grid()
+            VStack {
+                HStack {
+                    Text(TuningUtils.flatSymbol)
+                        .font(.system(size: 36))
+                    Spacer()
+                    Text(TuningUtils.sharpSymbol)
+                        .font(.system(size: 36))
+                }
+                .padding()
+                Spacer()
+            }
         }
         .sheet(isPresented: $showSheet) {
             MainContent()
@@ -33,16 +36,29 @@ struct Tuner: View {
 private struct MainContent: View {
     
     @EnvironmentObject var tuningManager: TuningManager
+    @State var useSharps = false
     
     var body: some View {
         VStack {
             Spacer()
-            Text(tuningManager.data.noteName())
+            Text(tuningManager.data.noteName(useSharps: useSharps))
                 .font(.system(size: 96))
             + Text("\(tuningManager.data.ocatave)")
                 .font(.system(size: 48))
                 .baselineOffset(36)
+            
+            Text("Frequency: \(Int(tuningManager.data.pitch)) Hz")
+                .font(.system(size: 24))
+            Text("Distance: \(tuningManager.data.distance)")
+                .font(.system(size: 16))
             Spacer()
+            HStack {
+                Spacer()
+                Toggle(isOn: $useSharps) {
+                    Text("\(TuningUtils.flatSymbol)/\(TuningUtils.sharpSymbol)")
+                }
+            }
+            .padding()
         }
         .presentationDetents([.medium])
         .presentationBackgroundInteraction(.enabled)

--- a/TunApp/TuningManager/TuningData.swift
+++ b/TunApp/TuningManager/TuningData.swift
@@ -13,7 +13,7 @@ struct TuningData {
     var ocatave: Int = 0
     var distance: Float = 0.0
     
-    func noteName(_ useSharps: Bool = false) -> String {
+    func noteName(useSharps: Bool = false) -> String {
         return TuningUtils.getNoteName(for: noteIndex, useSharps: useSharps)
     }
 }

--- a/TunApp/TuningManager/TuningData.swift
+++ b/TunApp/TuningManager/TuningData.swift
@@ -6,9 +6,14 @@
 //
 
 struct TuningData {
+    
     var pitch: Float = 0.0
     var amplitude: Float = 0.0
     var noteIndex: Int = 0
     var ocatave: Int = 0
     var distance: Float = 0.0
+    
+    func noteName(_ useSharps: Bool = false) -> String {
+        return TuningUtils.getNoteName(for: noteIndex, useSharps: useSharps)
+    }
 }

--- a/TunApp/TuningManager/TuningManager.swift
+++ b/TunApp/TuningManager/TuningManager.swift
@@ -70,5 +70,6 @@ class TuningManager: ObservableObject, HasAudioEngine {
         data.noteIndex = index
         data.ocatave = octave
         data.distance = frequency - Float(TuningUtils.noteFrequencies[index])
+        print(data.distance)
     }
 }

--- a/TunApp/TuningManager/TuningUtils.swift
+++ b/TunApp/TuningManager/TuningUtils.swift
@@ -7,6 +7,9 @@
 
 class TuningUtils {
     
+    static let sharpSymbol = "♯"
+    static let flatSymbol = "♭"
+    
     static let noteFrequencies = [16.35, 17.32, 18.35, 19.45, 20.6, 21.83, 23.12, 24.5, 25.96, 27.5, 29.14, 30.87]
     private static let noteNamesWithSharps = ["C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"]
     private static let noteNamesWithFlats = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"]

--- a/TunApp/TuningManager/TuningUtils.swift
+++ b/TunApp/TuningManager/TuningUtils.swift
@@ -14,8 +14,8 @@ class TuningUtils {
     private static let noteNamesWithSharps = ["C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"]
     private static let noteNamesWithFlats = ["C", "D♭", "D", "E♭", "E", "F", "G♭", "G", "A♭", "A", "B♭", "B"]
     
-    /*
-     Maps given pitch value to hardcoded octave represented by noteFrequencies array
+    /**
+     Maps the given pitch value to hardcoded octave represented by `noteFrequencies` array
      */
     static func getOcataveFrequency(for pitch: Float) -> Float {
         var frequency = pitch
@@ -37,3 +37,4 @@ class TuningUtils {
         return noteNames[abs(index % noteNames.count)]
     }
 }
+


### PR DESCRIPTION
This PR:
- Rebuilds UI using Grid component
- Basic configuration of main content sheet.

TODOs:
* Needle animation and x adjustment
* Tick markings and correct state
* Splash screen and app icon
* Fix negative octaves
* Continue audio playback 
* Block sheet from expansion/close 