### PR TITLE
[me] Fixes audio capture on resume 

### DIFF
--- a/TunApp.xcodeproj/project.pbxproj
+++ b/TunApp.xcodeproj/project.pbxproj
@@ -15,9 +15,22 @@
 		780C90232D3CB279006E24D4 /* TunApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TunApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		78B494292EF514C100336774 /* Exceptions for "TunApp" folder in "TunApp" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 780C90222D3CB279006E24D4 /* TunApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		780C90252D3CB279006E24D4 /* TunApp */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				78B494292EF514C100336774 /* Exceptions for "TunApp" folder in "TunApp" target */,
+			);
 			path = TunApp;
 			sourceTree = "<group>";
 		};
@@ -268,6 +281,7 @@
 				DEVELOPMENT_TEAM = FHXSPA8M8R;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TunApp/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app uses the microphone to capture audio.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -299,6 +313,7 @@
 				DEVELOPMENT_TEAM = FHXSPA8M8R;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = TunApp/Info.plist;
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "This app uses the microphone to capture audio.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/TunApp/Info.plist
+++ b/TunApp/Info.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+</dict>
+</plist>

--- a/TunApp/TunAppApp.swift
+++ b/TunApp/TunAppApp.swift
@@ -17,14 +17,19 @@ struct TunAppApp: App {
         WindowGroup {
             TunerScreen()
                 .environment(tuniningManager)
+                .onAppear() {
+                    tuniningManager.resume()
+                }
                 .onChange(of: scenePhase) { _, newPhase in
                     switch newPhase {
                     case .active:
-                        tuniningManager.start()
+                        if !tuniningManager.engine.avEngine.isRunning {
+                            tuniningManager.resume()
+                        }
                     case .background, .inactive:
-                        tuniningManager.stop()
+                        tuniningManager.pause()
                     default:
-                        tuniningManager.stop()
+                        break
                     }
                 }
         }


### PR DESCRIPTION
Was previously failing to resume audio capture on resume app from background/inactive scene phase. This PR:
- Adds robust resume/pause handling to `TuningManager`. Reinitializes current `PitchTap` on resume and nullifies on pause
- Adds new Signing/capabilities: BG modes > Audio, AirPlay, and Picture in Picture